### PR TITLE
fix update and delete clauses to use only ID and not all record values

### DIFF
--- a/src/texas_pgsql.erl
+++ b/src/texas_pgsql.erl
@@ -165,13 +165,13 @@ update(Conn, Table, Record, UpdateData) ->
   SQLCmd = "UPDATE " ++
            texas_sql:sql_field(Table, ?MODULE) ++
            texas_sql:set_clause(UpdateData, ?MODULE) ++
-           texas_sql:where_clause(Record, ?MODULE),
+           texas_sql:where_clause(texas_sql:clause(where, [{where, [{id, Record:id()}]}]), ?MODULE),
   case exec(SQLCmd, Conn) of
     {ok, _} ->
       UpdateRecord = lists:foldl(fun({Field, Value}, Rec) ->
               Rec:Field(Value)
           end, Record, UpdateData),
-      select(Conn, Table, all, [{where, UpdateRecord}]);
+      select(Conn, Table, all, [{where, [{id, UpdateRecord:id()}]}]);
     E -> E
   end.
 
@@ -179,7 +179,7 @@ update(Conn, Table, Record, UpdateData) ->
 delete(Conn, Table, Record) ->
   SQLCmd = "DELETE FROM " ++
            texas_sql:sql_field(Table, ?MODULE) ++
-           texas_sql:where_clause(Record, ?MODULE),
+           texas_sql:where_clause([{id, Record:id()}], ?MODULE),
   case exec(SQLCmd, Conn) of
     {ok, _} -> ok;
     E -> E


### PR DESCRIPTION
Currently, `texas` update function generates an update clause that puts un `WHERE` all values from the row. In the case where there are float values because of floating precision, the float stored in DB might not correspond to one that was fetched example difference is like 0.000000000001 it is enough though to make update fail.  
