### PR TITLE
Prefer fetch by id when available in update and delete fonctions.

### DIFF
--- a/src/texas_pgsql.erl
+++ b/src/texas_pgsql.erl
@@ -165,13 +165,13 @@ update(Conn, Table, Record, UpdateData) ->
   SQLCmd = "UPDATE " ++
            texas_sql:sql_field(Table, ?MODULE) ++
            texas_sql:set_clause(UpdateData, ?MODULE) ++
-           texas_sql:where_clause(Record, ?MODULE),
+           texas_sql:where_clause(texas_sql:clause(where, [{where, [{id, Record:id()}]}]), ?MODULE),
   case exec(SQLCmd, Conn) of
     {ok, _} ->
       UpdateRecord = lists:foldl(fun({Field, Value}, Rec) ->
               Rec:Field(Value)
           end, Record, UpdateData),
-      select(Conn, Table, all, [{where, UpdateRecord}]);
+      select(Conn, Table, all, [{where, [{id, UpdateRecord:id()}]}]);
     E -> E
   end.
 
@@ -179,7 +179,7 @@ update(Conn, Table, Record, UpdateData) ->
 delete(Conn, Table, Record) ->
   SQLCmd = "DELETE FROM " ++
            texas_sql:sql_field(Table, ?MODULE) ++
-           texas_sql:where_clause(Record, ?MODULE),
+           texas_sql:where_clause([{id, Record:id()}], ?MODULE),
   case exec(SQLCmd, Conn) of
     {ok, _} -> ok;
     E -> E

--- a/src/texas_pgsql.erl
+++ b/src/texas_pgsql.erl
@@ -165,7 +165,7 @@ update(Conn, Table, Record, UpdateData) ->
   SQLCmd = "UPDATE " ++
            texas_sql:sql_field(Table, ?MODULE) ++
            texas_sql:set_clause(UpdateData, ?MODULE) ++
-           texas_sql:where_clause(texas_sql:clause(where, [{where, [{id, Record:id()}]}]), ?MODULE),
+           where_for_update(Record),
   case exec(SQLCmd, Conn) of
     {ok, _} ->
       UpdateRecord = lists:foldl(fun({Field, Value}, Rec) ->
@@ -179,7 +179,7 @@ update(Conn, Table, Record, UpdateData) ->
 delete(Conn, Table, Record) ->
   SQLCmd = "DELETE FROM " ++
            texas_sql:sql_field(Table, ?MODULE) ++
-           texas_sql:where_clause([{id, Record:id()}], ?MODULE),
+           where_for_update(Record),
   case exec(SQLCmd, Conn) of
     {ok, _} -> ok;
     E -> E
@@ -234,3 +234,10 @@ sql(column_def, Name, Type, Len, Autoincrement, NotNull, Unique, Default) ->
 sql(notnull, {ok, true}) -> " NOT NULL";
 sql(unique, {ok, true}) -> " UNIQUE";
 sql(_, _) -> "".
+
+where_for_update(Record) ->
+  case Record:id() of
+    undefined -> texas_sql:where_clause(Record, ?MODULE);
+    _ -> texas_sql:where_clause(texas_sql:clause(where, [{where, [{id, Record:id()}]}]), ?MODULE)
+  end.
+

--- a/src/texas_pgsql.erl
+++ b/src/texas_pgsql.erl
@@ -171,7 +171,11 @@ update(Conn, Table, Record, UpdateData) ->
       UpdateRecord = lists:foldl(fun({Field, Value}, Rec) ->
               Rec:Field(Value)
           end, Record, UpdateData),
-      select(Conn, Table, all, [{where, [{id, UpdateRecord:id()}]}]);
+      WhereClause = case UpdateRecord:id() of
+                      undefined -> UpdateRecord;
+                      _ -> [{id, UpdateRecord:id()}]
+                    end,
+      select(Conn, Table, all, [{where, WhereClause}]);
     E -> E
   end.
 


### PR DESCRIPTION
Currently, texas update function generates an update clause that puts un WHERE all values from the row. In the case where there are float values because of floating precision, the float stored in DB might not correspond to one that was fetched example difference is like 0.000000000001 it is enough though to make an update (or delete) fail.